### PR TITLE
Add support for modularity

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,6 +33,13 @@ See this upstream Gradle issue about potentially providing a solution to this pr
 Gradle core: https://github.com/gradle/gradle/issues/1989. Hopefully an upstream solution to
 this will eliminate the need for this plugin.
 
+== Notes on Modularity
+
+This plugin tries to detect if the current project is modularized.
+If it is, the `module-path` is adapted instead of the class path.
+Since the classpath variable of gradle is cleared after the patch, plugins relying on it stop working.
+As a consequence, this plugin cannot be used together with https://github.com/java9-modularity/gradle-modules-plugin[org.javamodularity.moduleplugin].
+
 == Version Compatibility
 
 * Gradle 8.8+ (may work on earlier versions, but untested)

--- a/src/main/kotlin/com/redock/classpathtofile/listener/AbstractClasspathToFileActionListener.kt
+++ b/src/main/kotlin/com/redock/classpathtofile/listener/AbstractClasspathToFileActionListener.kt
@@ -26,7 +26,8 @@ abstract class AbstractClasspathToFileActionListener: TaskActionListener {
   fun classpathToFile(
     task: Task,
     jvmArgumentProviders: MutableList<CommandLineArgumentProvider>,
-    classpath: FileCollection
+    classpath: FileCollection,
+    isModule: Boolean
   ) {
 
     cpArgFile = File.createTempFile("classpath-${task.project.name.replace(" ", "_")}", null)
@@ -39,7 +40,12 @@ abstract class AbstractClasspathToFileActionListener: TaskActionListener {
     // TODO this doesn't currently handle wildcards, we should expand wildcards before writing to the arg file
     // see https://docs.oracle.com/javase/9/tools/java.htm#JSWOR-GUID-4856361B-8BFD-4964-AE84-121F5F6CF111
     OutputStreamWriter(FileOutputStream(cpArgFile), Charsets.UTF_8).use {
-      it.write("-cp \"\\")
+      if (isModule) {
+        it.write("--module-path")
+      } else {
+        it.write("-cp")
+      }
+      it.write(" \"\\")
       it.write(LINE_SEP)
       classpath.files.forEachIndexed { i, file  ->
         if(i > 0) {

--- a/src/main/kotlin/com/redock/classpathtofile/listener/JavaExecSpecActionListener.kt
+++ b/src/main/kotlin/com/redock/classpathtofile/listener/JavaExecSpecActionListener.kt
@@ -14,7 +14,7 @@ class JavaExecSpecActionListener(private val extension: ClasspathToFilePluginExt
       return
     }
 
-    classpathToFile(task, task.jvmArgumentProviders, task.classpath)
+    classpathToFile(task, task.jvmArgumentProviders, task.classpath, task.mainModule.isPresent)
     task.classpath = EmptyFileCollection
   }
 }

--- a/src/main/kotlin/com/redock/classpathtofile/listener/TestActionListener.kt
+++ b/src/main/kotlin/com/redock/classpathtofile/listener/TestActionListener.kt
@@ -15,7 +15,7 @@ class TestActionListener(private val extension: ClasspathToFilePluginExtension):
       return
     }
 
-    classpathToFile(task, task.jvmArgumentProviders, task.classpath)
+    classpathToFile(task, task.jvmArgumentProviders, task.classpath, false)
     task.classpath = EmptyFileCollection
   }
 }


### PR DESCRIPTION
In a modularized project, one need `--module-path` instead of `-cp`.

This PR adds support for it.